### PR TITLE
Revert clone --depth 1

### DIFF
--- a/amcfwm.sh
+++ b/amcfwm.sh
@@ -1756,7 +1756,7 @@ case "$1" in
 		fi
 		if [ ! -d "$HOME/amng" ]; then
 			echo "Preparing Firmware Repo"
-			git clone --depth 1 https://github.com/RMerl/asuswrt-merlin.ng amng
+			git clone https://github.com/RMerl/asuswrt-merlin.ng amng
 			echo
 		fi
 


### PR DESCRIPTION
A depth of 1 prevents easy checkout of the 386_x branch. Revert this change for now.

No impact on the toolchain repo since we don't checkout anything.